### PR TITLE
Fix REPOSITORIES config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can set up your own instance on [GitHub Pages](https://pages.github.com). Ju
 
     - `REPOSITORIES`: The repository containing your recipes. This is a JSON array in the following format:
         ```
-        [{"username":"<GitHub username>","repository":"<repository name>","branch":"<branch>"}]
+        [{"author":"<GitHub username>","repository":"<repository name>","branch":"<branch>"}]
         ```
         You an also add additional objects to the array to show recipes from multiple REPOSITORIES
 


### PR DESCRIPTION
In 4cc219d28bbc45f3b3dfb9fbf2cbba77e596f3c7 the `username` field was renamed to `author`. However I made #26  prior to that change, so the instructions added by the PR incorrectly still use the old naming.